### PR TITLE
feat: Add C++ devcontainer support

### DIFF
--- a/tmpl/.devcontainer/Dockerfile
+++ b/tmpl/.devcontainer/Dockerfile
@@ -1,0 +1,64 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-22.04
+
+USER root
+SHELL [ "/bin/bash", "-c" ]
+
+RUN export DEBIAN_FRONTEND=noninteractive; \
+    apt-get -qq update && apt-get -qq install --no-install-recommends \
+    bash-completion \
+    build-essential \
+    clang-15 \
+    clang-format-15 \
+    clang-tidy-15 \
+    curl \
+    g++-12 \
+    gcc-12 \
+    gdb \
+    git \
+    lldb-15 \
+    llvm-15 \
+    ninja-build \
+    pkg-config \
+    python3 \
+    python3-pip \
+    tar \
+    unzip \
+    zip \
+    zsh \
+    && apt-get -qq autoremove \
+    && apt-get -qq clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 120 --slave /usr/bin/g++ g++ /usr/bin/g++-12 \
+    && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 150 --slave /usr/bin/clang++ clang++ /usr/bin/clang++-15
+
+ARG CMAKE_VERSION="3.22.6"
+RUN declare -A archs=( ["amd64"]="x86_64" ["arm64"]="aarch64" ); \
+    architecture=$(dpkg --print-architecture); \
+    echo "Detected arch: $architecture => ${archs[$architecture]}"; \
+    [[ "${archs[$architecture]}" != "" ]] \
+    && mkdir -p /opt/cmake \
+    && CMAKE_BINARY_NAME="cmake-$CMAKE_VERSION-linux-${archs[$architecture]}.sh" \
+    && TMP_DIR=$(mktemp -d -t cmake-XXXXXXXXXX) \
+    && pushd "$TMP_DIR" \
+    && curl -sSL "https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/$CMAKE_BINARY_NAME" -O \
+    && sh "$TMP_DIR/$CMAKE_BINARY_NAME" --prefix=/opt/cmake --skip-license \
+    && popd \
+    && rm -rf "$TMP_DIR" \
+    && ln -s -t /usr/local/bin /opt/cmake/bin/cmake /opt/cmake/bin/ccmake /opt/cmake/bin/ctest /opt/cmake/bin/cpack
+
+# Setup ENV vars for vcpkg
+ENV VCPKG_ROOT=/usr/local/vcpkg \
+    VCPKG_NO_CI=1
+RUN mkdir -p "$VCPKG_ROOT" \
+    && chown vscode:vscode "$VCPKG_ROOT" \
+    && su vscode -c "git clone -c core.eol=lf -c core.autocrlf=false -c fsck.zeroPaddedFilemode=ignore -c fetch.fsck.zeroPaddedFilemode=ignore -c receive.fsck.zeroPaddedFilemode=ignore https://github.com/microsoft/vcpkg $VCPKG_ROOT" \
+    && VCPKG_DOWNLOADS="$HOME/.cache/vcpkg/downloads" \
+    && sh "$VCPKG_ROOT/bootstrap-vcpkg.sh" \
+    && rm -rf "$VCPKG_DOWNLOADS" \
+    && ln -s "$VCPKG_ROOT/vcpkg" "/usr/local/bin/vcpkg" \
+    && echo 'export VCPKG_DOWNLOADS="$HOME/.cache/vcpkg/downloads"' >> ~vscode/.zshenv \
+    && echo 'export VCPKG_DOWNLOADS="$HOME/.cache/vcpkg/downloads"' >> ~vscode/.bash_profile
+
+USER vscode
+
+RUN python3 -m pip install --user pipenv

--- a/tmpl/.devcontainer/devcontainer.json
+++ b/tmpl/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/cpp
+{
+    "name": "C++",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "EditorConfig.EditorConfig",
+                "github.vscode-github-actions",
+                "lextudio.restructuredtext",
+                "ms-python.python",
+                "ms-vscode.cpptools",
+                "ms-vscode.cmake-tools",
+                "trond-snekvik.simple-rst",
+                "twxs.cmake",
+            ]
+        }
+    },
+    "postCreateCommand": "cd ${containerWorkspaceFolder}/docs && pipenv sync --dev",
+}

--- a/tmpl/docs/Pipfile
+++ b/tmpl/docs/Pipfile
@@ -12,6 +12,3 @@ furo = "==2023.5.20"
 [dev-packages]
 esbonio = "*"
 doc8 = "*"
-
-[requires]
-python_version = "3.11"

--- a/tmpl/docs/Pipfile.lock
+++ b/tmpl/docs/Pipfile.lock
@@ -1,12 +1,10 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b22aeecf139d64e7ac6db5715cb4a65f2d1904702b89ca645e72b3b4e81a3305"
+            "sha256": "6b4b462987d15cbb032885bb7226fce8beb474f1ba04db4b52387e58bf6e64ec"
         },
         "pipfile-spec": 6,
-        "requires": {
-            "python_version": "3.11"
-        },
+        "requires": {},
         "sources": [
             {
                 "name": "pypi",
@@ -128,14 +126,6 @@
             ],
             "markers": "python_full_version >= '3.7.0'",
             "version": "==3.2.0"
-        },
-        "colorama": {
-            "hashes": [
-                "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44",
-                "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
-            ],
-            "markers": "sys_platform == 'win32'",
-            "version": "==0.4.6"
         },
         "docutils": {
             "hashes": [
@@ -274,11 +264,11 @@
         },
         "sphinx": {
             "hashes": [
-                "sha256:60c5e04756c1709a98845ed27a2eed7a556af3993afb66e77fec48189f742616",
-                "sha256:61e025f788c5977d9412587e733733a289e2b9fdc2fef8868ddfbfc4ccfe881d"
+                "sha256:8f336d0221c3beb23006b3164ed1d46db9cebcce9cb41cdb9c5ecd4bcc509be0",
+                "sha256:9bdfb5a2b28351d4fdf40a63cd006dbad727f793b243e669fc950d7116c634af"
             ],
             "index": "pypi",
-            "version": "==7.0.1"
+            "version": "==7.1.0"
         },
         "sphinx-basic-ng": {
             "hashes": [
@@ -490,14 +480,6 @@
             "markers": "python_full_version >= '3.7.0'",
             "version": "==3.2.0"
         },
-        "colorama": {
-            "hashes": [
-                "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44",
-                "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
-            ],
-            "markers": "sys_platform == 'win32'",
-            "version": "==0.4.6"
-        },
         "doc8": {
             "hashes": [
                 "sha256:d97a93e8f5a2efc4713a0804657dedad83745cca4cd1d88de9186f77f9776004",
@@ -521,6 +503,14 @@
             ],
             "index": "pypi",
             "version": "==0.16.1"
+        },
+        "exceptiongroup": {
+            "hashes": [
+                "sha256:12c3e887d6485d16943a309616de20ae5582633e0a2eda17f4e10fd61c1e8af5",
+                "sha256:e346e69d186172ca7cf029c8c1d16235aa0e04035e5750b4b95039e65204328f"
+            ],
+            "markers": "python_version < '3.11'",
+            "version": "==1.1.2"
         },
         "idna": {
             "hashes": [
@@ -673,11 +663,11 @@
         },
         "sphinx": {
             "hashes": [
-                "sha256:60c5e04756c1709a98845ed27a2eed7a556af3993afb66e77fec48189f742616",
-                "sha256:61e025f788c5977d9412587e733733a289e2b9fdc2fef8868ddfbfc4ccfe881d"
+                "sha256:8f336d0221c3beb23006b3164ed1d46db9cebcce9cb41cdb9c5ecd4bcc509be0",
+                "sha256:9bdfb5a2b28351d4fdf40a63cd006dbad727f793b243e669fc950d7116c634af"
             ],
             "index": "pypi",
-            "version": "==7.0.1"
+            "version": "==7.1.0"
         },
         "sphinxcontrib-applehelp": {
             "hashes": [
@@ -735,6 +725,14 @@
             "markers": "python_version >= '3.8'",
             "version": "==5.1.0"
         },
+        "tomli": {
+            "hashes": [
+                "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+                "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
+            ],
+            "markers": "python_version < '3.11'",
+            "version": "==2.0.1"
+        },
         "typeguard": {
             "hashes": [
                 "sha256:bbe993854385284ab42fd5bd3bee6f6556577ce8b50696d6cb956d704f286c8e",
@@ -742,6 +740,14 @@
             ],
             "markers": "python_full_version >= '3.7.4'",
             "version": "==3.0.2"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36",
+                "sha256:b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2"
+            ],
+            "markers": "python_version < '3.11'",
+            "version": "==4.7.1"
         },
         "urllib3": {
             "hashes": [


### PR DESCRIPTION

The default cpp image can't be used due to broken vcpkg support.
Specifically it performs a shallow clone of the vcpkg repository which
breaks versioning.