### PR TITLE
fix!: Remove ever changing copier options

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -32,16 +32,6 @@ header_only:
     type: bool
     help: Generate a header only library project
 
-semver:
-    type: str
-    help: The current (semantic) version of the project
-    default: 0.0.0-alpha.1
-
-buildver:
-    type: str
-    help: The CMake build version
-    default: "{{ '{}.0'.format(semver.split('-')[0]) }}"
-
 year:
     type: str
     help: The copyright year

--- a/tmpl/CMakeLists.txt.jinja
+++ b/tmpl/CMakeLists.txt.jinja
@@ -23,7 +23,7 @@ endif()
 
 ########################################################################
 project({{project_slug}}
-    VERSION {{buildver}}
+    VERSION 0.0.0.0
     LANGUAGES CXX
 )
 

--- a/tmpl/docs/conf.py.jinja
+++ b/tmpl/docs/conf.py.jinja
@@ -22,7 +22,7 @@ copyright = '{{year}}, {{full_name}}'
 author = '{{full_name}}'
 
 # The full version, including alpha/beta/rc tags
-release = '{{semver}}'
+release = ' 0.0.0-alpha.1'
 
 
 # -- General configuration ---------------------------------------------------

--- a/tmpl/vcpkg.json.jinja
+++ b/tmpl/vcpkg.json.jinja
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/master/docs/vcpkg.schema.json",
     "name": "{{project_slug}}",
-    "version-semver": "{{semver}}",
+    "version-semver": "0.0.0-alpha.1",
     "homepage": "https://github.com/deeplex/{{project_slug}}",
     "dependencies": [
         "concrete"


### PR DESCRIPTION
Updating options and editing affected lines outside of copiers purview causes conflicts. This is problematic for version options which frequently change outside of a template update basically causing a conflict on each update.

Instead hardcode versions to 0 and let copier's update-diff do the work.
