### PR TITLE
feat: Add workaround config option

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -28,6 +28,10 @@ header_config:
     type: bool
     help: Generate a configuration header with values from configure time.
 
+workaround_header:
+    type: bool
+    help: Generate a header with (compiler/etc.) workaround configuration macros.
+
 header_only:
     type: bool
     help: Generate a header only library project

--- a/tmpl/CMakeLists.txt.jinja
+++ b/tmpl/CMakeLists.txt.jinja
@@ -43,6 +43,10 @@ endif()
 
 ########################################################################
 # options
+{% if workaround_header %}
+option(DPLX_{{namespace|upper}}_DISABLE_WORKAROUNDS "Disable all workarounds" OFF)
+option(DPLX_{{namespace|upper}}_FLAG_OUTDATED_WORKAROUNDS "Emit compiler errors for workarounds which are active, but haven't been validated for this version" OFF)
+{%- endif %}
 
 ########################################################################
 # dependencies

--- a/tmpl/CMakeLists.txt.jinja
+++ b/tmpl/CMakeLists.txt.jinja
@@ -1,4 +1,4 @@
-# Written in 2017, 2019 by Henrik Steffen Gaßmann <henrik@gassmann.onl>
+# Written in 2017, 2019, 2022-2023 by Henrik Steffen Gaßmann <henrik@gassmann.onl>
 #
 # To the extent possible under law, the author(s) have dedicated all
 # copyright and related and neighboring rights to this software to the
@@ -10,7 +10,7 @@
 #     http://creativecommons.org/publicdomain/zero/1.0/
 #
 ########################################################################
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.22)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/tools/cmake/")
 
 ########################################################################

--- a/tmpl/docs/conf.py.jinja
+++ b/tmpl/docs/conf.py.jinja
@@ -18,7 +18,7 @@
 # -- Project information -----------------------------------------------------
 
 project = '{{project_name}}'
-copyright = '{{year}}, {{full_name}}'
+copyright = '{{year}} {{full_name}}'
 author = '{{full_name}}'
 
 # The full version, including alpha/beta/rc tags

--- a/tmpl/sources.cmake.jinja
+++ b/tmpl/sources.cmake.jinja
@@ -1,11 +1,35 @@
 dplx_target_sources({{project_slug}}
     TEST_TARGET {{project_slug}}-tests
-    MODE SMART_{% if header_only == True %}HEADER_ONLY{% else %}SOURCE{% endif %} MERGED_LAYOUT
+    MODE SMART_{% if header_only %}HEADER_ONLY{% else %}SOURCE{% endif %} MERGED_LAYOUT
     BASE_DIR dplx
 
     PUBLIC
         {{namespace}}
+{%- if header_only %}
+{%- if header_config %}
+        {{namespace}}/config
+{%- endif %}
+{%- if workaround_header %}
+        {{namespace}}/detail/workaround
+{%- endif %}
+{%- endif %}
 )
+{%- if not header_only and (header_config or workaround_header) %}
+
+dplx_target_sources({{project_slug}}
+    TEST_TARGET {{project_slug}}-tests
+    MODE SMART_HEADER_ONLY MERGED_LAYOUT
+    BASE_DIR dplx
+
+    PUBLIC
+{%- if header_config %}
+        {{namespace}}/config
+{%- endif %}
+{%- if workaround_header %}
+        {{namespace}}/detail/workaround
+{%- endif %}
+)
+{%- endif %}
 {%- if header_config %}
 
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/generated/src/dplx/{{namespace}}/detail)

--- a/tmpl/src/dplx/{% if not header_only %}{{namespace}}.cpp{% endif %}.jinja
+++ b/tmpl/src/dplx/{% if not header_only %}{{namespace}}.cpp{% endif %}.jinja
@@ -1,5 +1,5 @@
 
-// Copyright {{full_name}} {{year}}.
+// Copyright {{year}} {{full_name}}
 //
 // Distributed under the Boost Software License, Version 1.0.
 //         (See accompanying file LICENSE or copy at

--- a/tmpl/src/dplx/{{namespace}}.hpp.jinja
+++ b/tmpl/src/dplx/{{namespace}}.hpp.jinja
@@ -1,5 +1,5 @@
 
-// Copyright {{full_name}} {{year}}.
+// Copyright {{year}} {{full_name}}
 //
 // Distributed under the Boost Software License, Version 1.0.
 //         (See accompanying file LICENSE or copy at

--- a/tmpl/src/dplx/{{namespace}}.test.cpp.jinja
+++ b/tmpl/src/dplx/{{namespace}}.test.cpp.jinja
@@ -1,5 +1,5 @@
 
-// Copyright {{full_name}} {{year}}.
+// Copyright {{year}} {{full_name}}
 //
 // Distributed under the Boost Software License, Version 1.0.
 //         (See accompanying file LICENSE or copy at

--- a/tmpl/src/dplx/{{namespace}}/detail/{% if workaround_header %}workaround.hpp{% endif %}.jinja
+++ b/tmpl/src/dplx/{{namespace}}/detail/{% if workaround_header %}workaround.hpp{% endif %}.jinja
@@ -1,0 +1,34 @@
+
+// Copyright {{year}} {{full_name}}
+//
+// Distributed under the Boost Software License, Version 1.0.
+//         (See accompanying file LICENSE or copy at
+//           https://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <dplx/predef/version_number.h>
+#include <dplx/predef/workaround.h>
+
+{% if header_config %}#include <dplx/{{namespace}}/config.hpp>{% endif %}
+// NOLINTBEGIN(cppcoreguidelines-macro-usage)
+
+// these macros are very similar to those in <dplx/predef/other/workaround.h>
+// but offer library specific configuration knobs
+
+// guard for bugs which have been resolved with a known (compiler) version
+#define DPLX_{{namespace|upper}}_WORKAROUND(symbol, comp, major, minor, patch)                \
+    DPLX_XDEF_WORKAROUND(DPLX_{{namespace|upper}}_DISABLE_WORKAROUNDS, symbol, comp, major,   \
+                         minor, patch)
+
+// guard for bugs which have _not_ been resolved known (compiler) version
+// i.e. we need to periodically test whether they have been resolved
+// after which we can move them in the upper category
+#define DPLX_{{namespace|upper}}_WORKAROUND_TESTED_AT(symbol, major, minor, patch)            \
+    DPLX_XDEF_WORKAROUND_TESTED_AT(DPLX_{{namespace|upper}}_DISABLE_WORKAROUNDS,              \
+                                   DPLX_{{namespace|upper}}_FLAG_OUTDATED_WORKAROUNDS,        \
+                                   symbol, major, minor, patch)
+
+////////////////////////////////////////////////////////////////////////////////
+
+// NOLINTEND(cppcoreguidelines-macro-usage)

--- a/tmpl/src/dplx/{{namespace}}/detail/{% if workaround_header %}workaround.test.cpp{% endif %}.jinja
+++ b/tmpl/src/dplx/{{namespace}}/detail/{% if workaround_header %}workaround.test.cpp{% endif %}.jinja
@@ -1,0 +1,12 @@
+
+// Copyright {{year}} {{full_name}}
+//
+// Distributed under the Boost Software License, Version 1.0.
+//         (See accompanying file LICENSE or copy at
+//           https://www.boost.org/LICENSE_1_0.txt)
+
+#include "dplx/{{namespace}}/detail/workaround.hpp"
+
+namespace {{namespace}}_tests
+{
+}

--- a/tmpl/src/dplx/{{namespace}}/{% if header_config %}config.hpp{% endif %}.jinja
+++ b/tmpl/src/dplx/{{namespace}}/{% if header_config %}config.hpp{% endif %}.jinja
@@ -11,3 +11,11 @@
 #if __has_include(<dplx/{{namespace}}/detail/config.hpp>)
 #include <dplx/{{namespace}}/detail/config.hpp>
 #endif
+{% if workaround_header %}
+#if !defined(DPLX_{{namespace|upper}}_DISABLE_WORKAROUNDS)
+#define DPLX_{{namespace|upper}}_DISABLE_WORKAROUNDS 0
+#endif
+#if !defined(DPLX_{{namespace|upper}}_FLAG_OUTDATED_WORKAROUNDS)
+#define DPLX_{{namespace|upper}}_FLAG_OUTDATED_WORKAROUNDS 0
+#endif
+{%- endif %}

--- a/tmpl/src/dplx/{{namespace}}/{% if header_config %}config.test.cpp{% endif %}.jinja
+++ b/tmpl/src/dplx/{{namespace}}/{% if header_config %}config.test.cpp{% endif %}.jinja
@@ -1,0 +1,12 @@
+
+// Copyright {{year}} {{full_name}}
+//
+// Distributed under the Boost Software License, Version 1.0.
+//         (See accompanying file LICENSE or copy at
+//           https://www.boost.org/LICENSE_1_0.txt)
+
+#include "dplx/{{namespace}}/config.hpp"
+
+namespace {{namespace}}_tests
+{
+}

--- a/tmpl/src/{{namespace}}_tests/test_utils.hpp.jinja
+++ b/tmpl/src/{{namespace}}_tests/test_utils.hpp.jinja
@@ -1,5 +1,5 @@
 
-// Copyright {{full_name}} {{year}}
+// Copyright {{year}} {{full_name}}
 //
 // Distributed under the Boost Software License, Version 1.0.
 //         (See accompanying file LICENSE or copy at

--- a/tmpl/tools/{% if header_config %}config.hpp.in{% endif %}.jinja
+++ b/tmpl/tools/{% if header_config %}config.hpp.in{% endif %}.jinja
@@ -11,6 +11,10 @@
 // NOLINTBEGIN(cppcoreguidelines-macro-usage)
 
 // #cmakedefine01
+{% if workaround_header %}
+#cmakedefine01 DPLX_{{namespace|upper}}_DISABLE_WORKAROUNDS
+#cmakedefine01 DPLX_{{namespace|upper}}_FLAG_OUTDATED_WORKAROUNDS
+{%- endif %}
 
 // NOLINTEND(cppcoreguidelines-macro-usage)
 // NOLINTEND(modernize-macro-to-enum)


### PR DESCRIPTION
Add an option to generate a workaround configuration header like the ones currently in use in concrete/deeppack/deeplog.